### PR TITLE
Remove unnecessary option

### DIFF
--- a/.rollup.js
+++ b/.rollup.js
@@ -9,7 +9,7 @@ export default {
 	plugins: [
 		babel({
 			presets: [
-				['@babel/env', { modules: false, targets: { node: 6 } }]
+				['@babel/env', { targets: { node: 6 } }]
 			]
 		})
 	]


### PR DESCRIPTION
Since the last major release modules are applied out of the box for both babel-loader and rollup-plugin-babel